### PR TITLE
Using the -d flag causes the install to fail

### DIFF
--- a/content/docs/installation.mdx
+++ b/content/docs/installation.mdx
@@ -14,7 +14,7 @@ description: How to install dependencies and organize your app structure.
 
     Run the `init` (with default options) command to create a new Next.js project or set up an existing one:
 
-    <InstallationCommand command="npx shadcn@canary init -d"/>
+    <InstallationCommand command="npx shadcn@canary init"/>
 
     <Step>That's it</Step>
 


### PR DESCRIPTION
It's a known issue in [shadcn-ui](https://github.com/shadcn-ui/ui/issues/6924) that the `-d` flag causes the install to fail :
```
will@LAPTOP:~/$ bunx --bun shadcn@canary init -d
✔ Preflight checks.
✔ Verifying framework. Found Next.js.
✔ Validating Tailwind CSS config. Found v4.
✔ Validating import alias.

Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

Validation failed:
- tailwind: Required
```

If `-d` flag is removed, the install works :

```
will@LAPTOP:~/$ bunx --bun shadcn@canary init
✔ Preflight checks.
✔ Verifying framework. Found Next.js.
✔ Validating Tailwind CSS config. Found v4.
✔ Validating import alias.
✔ Which color would you like to use as the base color? › Neutral
✔ Writing components.json.
✔ Checking registry.
✔ Updating CSS variables in src/app/globals.css
✔ Installing dependencies.
✔ Created 1 file:
  - src/lib/utils.ts

Success! Project initialization completed.
You may now add components.
```